### PR TITLE
Add CanCanCan Authorization and Implement Delete Functionality

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,3 +76,5 @@ end
 gem 'rubocop', '>= 1.0', '< 2.0'
 
 gem 'devise', '~> 4.9'
+
+gem 'cancancan'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,7 @@ GEM
     bootsnap (1.16.0)
       msgpack (~> 1.2)
     builder (3.2.4)
+    cancancan (3.5.0)
     capybara (3.39.2)
       addressable
       matrix
@@ -269,6 +270,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
+  cancancan
   capybara
   debug
   devise (~> 4.9)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,19 @@
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    user ||= User.new # guest user (not logged in)
+
+    # Define abilities for the different user roles
+    can :manage, :all if user.role == 'admin'
+
+    can :destroy, Post, user_id: user.id
+    can :destroy, Comment, user_id: user.id
+
+    can :create, Post
+    can :create, Comment
+
+    can :read, Post
+    can :read, Comment
+  end
+end

--- a/db/migrate/20230707174211_add_role_to_users.rb
+++ b/db/migrate/20230707174211_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :role, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_07_101524) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_07_174211) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -64,6 +64,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_07_101524) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
+    t.string "role"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 


### PR DESCRIPTION
# Description:
This pull request addresses the project requirements by installing CanCanCan for role-based authorization and implementing the delete functionality for posts and comments. Additionally, it adds a role column to the users table using a migration.

## Changes Made:

1. Installed CanCanCan gem in the project.
2. Added a role column to the users table using a migration.
3. Implemented authorization using CanCanCan for post deletion functionality.
4. Added a "Delete" button to the post view, ensuring that only authorized users can see it.
5. Implemented authorization using CanCanCan for comment deletion functionality.
6. Added a "Delete" button to the comment view, ensuring that only authorized users can see it.

# N/B: I would love to inform you that I worked on this project alone, since I have no partner to pair with, as it is evident below::
<img width="1281" alt="collaboration" src="https://github.com/Odongo006/Rails_blog_App/assets/51127665/4222ea91-ea12-4e8c-bd86-5ed364d7a8f7">

Please review the changes and merge them into the main branch. Thank you.